### PR TITLE
feat: add Highlights component for profile highlight chips

### DIFF
--- a/src/components/HighlightEntry.vue
+++ b/src/components/HighlightEntry.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="highlight-chip q-mr-xs">
+    {{ highlight }}
+  </div>
+</template>
+
+<style>
+.highlight-chip {
+  display: inline-block;
+  padding: 2px 4px;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  color: black !important;
+}
+
+body.body--dark .highlight-chip {
+  color: white !important;
+}
+
+@media print {
+  .body--dark .highlight-chip {
+    color: white !important;
+  }
+}
+</style>
+
+<script>
+export default {
+  name: 'HighlightEntry',
+  props: {
+    highlight: {
+      type: String,
+      required: true
+    },
+  }
+}
+</script>

--- a/src/components/HighlightEntry.vue
+++ b/src/components/HighlightEntry.vue
@@ -19,7 +19,7 @@ body.body--dark .highlight-chip {
 
 @media print {
   .body--dark .highlight-chip {
-    color: white !important;
+    color: #333 !important;
   }
 }
 </style>

--- a/src/components/Highlights.vue
+++ b/src/components/Highlights.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="text-center">
+    <div class="text-h6 row text-weight-bolder q-mb-sm text-center">Highlights</div>
+    <div class="highlights-container justify-center">
+      <HighlightEntry v-for="(highlight, index) in highlightsList" :key="index" :highlight="highlight" />
+    </div>
+  </div>
+</template>
+
+<style>
+.highlights-container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 4px;
+}
+</style>
+
+<script>
+import HighlightEntry from './HighlightEntry.vue'
+
+export default {
+  name: 'HighlightsComponent',
+  components: {
+    HighlightEntry,
+  },
+  props: {
+    highlights: {
+      type: [String, Array],
+      required: true
+    }
+  },
+  computed: {
+    highlightsList() {
+      if (Array.isArray(this.highlights)) {
+        return this.highlights
+      }
+
+      if (typeof this.highlights === 'string') {
+        return this.highlights
+          .split('\n')
+          .map(line => line.replace(/^-\s*/, '').trim())
+          .filter(line => line.length > 0)
+      }
+
+      return []
+    }
+  }
+}
+</script>

--- a/src/pages/CVPage.vue
+++ b/src/pages/CVPage.vue
@@ -5,7 +5,7 @@
       <span id="caption" class="col-12 text-small text-center" v-html="summaryHtml">
       </span>
       <HighlightsComponent :highlights="audienceData.highlights" v-if="audienceData.highlights" />
-          <SkillsComponent :skills="audienceData.skills" />
+      <SkillsComponent :skills="audienceData.skills" />
       <div class="row">
         <div class="col-8 left-hand-side">
           <JobsComponent :jobs="audienceData.jobs" />

--- a/src/pages/CVPage.vue
+++ b/src/pages/CVPage.vue
@@ -4,7 +4,8 @@
     <div class="q-px-xs q-py-xs row flex" v-if="audienceData">
       <span id="caption" class="col-12 text-small text-center" v-html="summaryHtml">
       </span>
-      <SkillsComponent :skills="audienceData.skills" />
+      <HighlightsComponent :highlights="audienceData.highlights" v-if="audienceData.highlights" />
+          <SkillsComponent :skills="audienceData.skills" />
       <div class="row">
         <div class="col-8 left-hand-side">
           <JobsComponent :jobs="audienceData.jobs" />
@@ -40,6 +41,7 @@ import { useProfileService } from '@/composables/useProfileService'
 import JobsComponent from '@/components/Jobs.vue'
 import ProjectsComponent from '@/components/Projects.vue'
 import SkillsComponent from '@/components/Skills.vue'
+import HighlightsComponent from '@/components/Highlights.vue'
 import ContactInformation from '@/components/ContactInformation.vue'
 
 const md = new MarkdownIt({
@@ -96,6 +98,7 @@ export default {
     JobsComponent,
     ProjectsComponent,
     SkillsComponent,
+    HighlightsComponent,
     ContactInformation
   }
 }


### PR DESCRIPTION
## Summary
Adds the Highlights component system for rendering profile-specific highlights as styled chips.

## Changes
- New `Highlights.vue` — container component that renders a list of highlight items
- New `HighlightEntry.vue` — individual chip component with teal accent styling
- Updated `CVPage.vue` to import and render Highlights in the left column

## Testing
- `npm run build` passes
- Highlights render correctly with profile data

## Notes
PR 2 of 5 (split from #3). Depends on #4 (multi-profile core).