### PR TITLE
feat: add dark mode toggle, Myriad Pro font, and UI polish

### DIFF
--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -4,6 +4,18 @@
       class="bg-primary text-white shadow-2"
       :class="{ 'floating-toolbar': isScrolled }"
     >
+    <q-btn 
+      flat 
+      round 
+      :icon="$q.dark.isActive ? 'light_mode' : 'dark_mode'" 
+      @click="toggleDarkMode"
+      class="q-mr-sm"
+    >
+      <q-tooltip>{{ $q.dark.isActive ? 'Light Mode' : 'Dark Mode' }}</q-tooltip>
+    </q-btn>
+
+    <q-separator dark vertical inset class="q-mr-sm" />
+
     <q-space />
 
     <q-breadcrumbs active-color="#CE4479" style="font-size: 16px" class="justify-center">
@@ -73,6 +85,7 @@
 <script>
 import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { useQuasar } from 'quasar'
 import { useProfileService } from '@/composables/useProfileService'
 
 export default {
@@ -81,6 +94,7 @@ export default {
   setup() {
     const router = useRouter()
     const route = useRoute()
+    const $q = useQuasar()
     const isScrolled = ref(false)
     
     const {
@@ -124,7 +138,16 @@ export default {
       })
     }
 
+    const toggleDarkMode = () => {
+      $q.dark.toggle()
+      localStorage.setItem('darkMode', $q.dark.isActive)
+    }
+
     onMounted(() => {
+      const savedDarkMode = localStorage.getItem('darkMode')
+      if (savedDarkMode !== null) {
+        $q.dark.set(savedDarkMode === 'true')
+      }
       window.addEventListener('scroll', handleScroll)
     })
 
@@ -139,7 +162,9 @@ export default {
       currentProfile,
       formatProfileName,
       selectProfileAndNavigate,
-      handleAudienceSelect
+      handleAudienceSelect,
+      toggleDarkMode,
+      $q
     }
   }
 }

--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -95,6 +95,13 @@ export default {
     const router = useRouter()
     const route = useRoute()
     const $q = useQuasar()
+
+    // Restore theme immediately in setup() to prevent flash of wrong theme
+    const savedTheme = localStorage.getItem('darkMode')
+    if (savedTheme !== null) {
+      $q.dark.set(savedTheme === 'true')
+    }
+
     const isScrolled = ref(false)
     
     const {
@@ -144,10 +151,6 @@ export default {
     }
 
     onMounted(() => {
-      const savedDarkMode = localStorage.getItem('darkMode')
-      if (savedDarkMode !== null) {
-        $q.dark.set(savedDarkMode === 'true')
-      }
       window.addEventListener('scroll', handleScroll)
     })
 

--- a/src/quasar-user-options.js
+++ b/src/quasar-user-options.js
@@ -2,6 +2,7 @@
 import './styles/quasar.sass'
 import lang from 'quasar/lang/en-GB.js'
 import '@quasar/extras/material-icons/material-icons.css'
+import '@quasar/extras/fontawesome-v6/fontawesome-v6.css'
 
 // To be used on app.use(Quasar, { ... })
 export default {

--- a/src/styles/application.sass
+++ b/src/styles/application.sass
@@ -1,4 +1,5 @@
 body
+  font-family: "Myriad Pro", Tahoma
   #wrapper
     #name,
     #projects


### PR DESCRIPTION
## Summary
Adds visual polish to the multi-profile CV system with dark mode support, professional typography, and FontAwesome icon integration.

## Changes
- **Dark mode toggle** in ToolBar with localStorage persistence and light/dark mode icon
- **Myriad Pro** as global body font family in application.sass
- **FontAwesome v6** CSS import via quasar-user-options.js (enables social icons in ContactInformation)

## Testing
- `npm run build` passes cleanly (no errors)
- Dark mode toggles correctly via toolbar button
- Font renders consistently across all components
- FontAwesome icons (LinkedIn, GitHub, Globe) render in ContactInformation

## Notes
PR 3 of 5 (split from #3). Depends on #4 (multi-profile core).