### PR TITLE
style: add comprehensive print layout styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <link rel="stylesheet" href="<%= BASE_URL %>print.css">
     <title>QuikCV</title>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <link rel="stylesheet" href="<%= BASE_URL %>print.css">
+    <link rel="stylesheet" href="<%= BASE_URL %>print.css" media="print">
     <title>QuikCV</title>
   </head>
   <body>

--- a/public/print.css
+++ b/public/print.css
@@ -1,0 +1,17 @@
+@media print {
+  .experience {
+    page-break-inside: avoid !important;
+    break-inside: avoid-page !important;
+    display: block !important;
+    widows: 2 !important;
+    orphans: 2 !important;
+  }
+
+  .project-description {
+    page-break-inside: avoid !important;
+    break-inside: avoid-page !important;
+    display: block !important;
+    widows: 2 !important;
+    orphans: 2 !important;
+  }
+}

--- a/public/print.css
+++ b/public/print.css
@@ -1,13 +1,5 @@
 @media print {
-  .experience {
-    page-break-inside: avoid !important;
-    break-inside: avoid-page !important;
-    display: block !important;
-    widows: 2 !important;
-    orphans: 2 !important;
-  }
-
-  .project-description {
+  .experience, .project-description {
     page-break-inside: avoid !important;
     break-inside: avoid-page !important;
     display: block !important;

--- a/src/pages/CVPage.vue
+++ b/src/pages/CVPage.vue
@@ -4,8 +4,8 @@
     <div class="q-px-xs q-py-xs row flex" v-if="audienceData">
       <span id="caption" class="col-12 text-small text-center" v-html="summaryHtml">
       </span>
-      <SkillsComponent :skills="audienceData.skills" />
-      <div class="row">
+       <SkillsComponent :skills="audienceData.skills" />
+      <div class="row experience-projects-row">
         <div class="col-8 left-hand-side">
           <JobsComponent :jobs="audienceData.jobs" />
         </div>

--- a/src/styles/application.sass
+++ b/src/styles/application.sass
@@ -82,3 +82,86 @@ body
 
   .right-hand-side
     padding-left: 0.5rem
+
+@media print
+  #toolbar
+    display: none
+
+// Print-specific enhancements (added for new CV components)
+@media print
+  .q-page
+    padding: 0 !important
+    margin: 0 !important
+
+  .q-spinner,
+  .q-btn
+    display: none !important
+
+  .q-separator
+    display: none
+
+  .q-card
+    border: none !important
+    box-shadow: none !important
+
+  .highlight-chip,
+  body.body--dark .highlight-chip
+    background: white !important
+    color: black !important
+
+  #skills
+    width: 100% !important
+    margin-top: 0.5rem !important
+    margin-bottom: 0.5rem !important
+
+  #skills-list
+    list-style-type: none
+    padding: 0
+    margin: 0
+
+  #skills-list .skill
+    display: inline-block !important
+    padding: 2px 4px
+    color: black !important
+    font-family: Georgia, "Times New Roman", Times, serif
+    font-size: 11pt
+    margin-right: 8px
+    flex: 1 1 auto
+    text-align: center
+
+  #skills-list .skill b
+    color: #333
+
+  .left-hand-side
+    width: 65% !important
+    float: left !important
+    clear: none !important
+
+    border-right: 1px solid #ccc
+    padding-right: 0.5rem
+
+  .right-hand-side
+    width: 33% !important
+    float: right !important
+    clear: none !important
+    padding-left: 0.5rem
+
+  // Consistent section spacing - no forced page breaks
+  .text-h6
+    margin-top: 0.5rem
+    margin-bottom: 0.3rem
+
+  // Ensure sections flow naturally without forced breaks
+  section, .section
+    margin-bottom: 0.5rem
+    page-break-inside: auto
+    break-inside: auto
+
+  a[href^="http"]:after
+    content: " (" attr(href) ")"
+    font-size: 0.8em
+    color: #999
+
+  @page
+    margin: 1cm
+    size: A4

--- a/src/styles/application.sass
+++ b/src/styles/application.sass
@@ -132,6 +132,10 @@ body
   #skills-list .skill b
     color: #333
 
+  .experience-projects-row
+    break-before: page
+    page-break-before: always
+
   .left-hand-side
     width: 65% !important
     float: left !important
@@ -146,12 +150,12 @@ body
     clear: none !important
     padding-left: 0.5rem
 
-  // Consistent section spacing - no forced page breaks
+  // Consistent section spacing
   .text-h6
     margin-top: 0.5rem
     margin-bottom: 0.3rem
 
-  // Ensure sections flow naturally without forced breaks
+  // Ensure sections flow naturally within pages
   section, .section
     margin-bottom: 0.5rem
     page-break-inside: auto

--- a/src/styles/application.sass
+++ b/src/styles/application.sass
@@ -83,12 +83,15 @@ body
   .right-hand-side
     padding-left: 0.5rem
 
+@page
+  margin: 1cm
+  size: A4
+
 @media print
   #toolbar
     display: none
 
-// Print-specific enhancements (added for new CV components)
-@media print
+  // Print-specific enhancements (added for new CV components)
   .q-page
     padding: 0 !important
     margin: 0 !important
@@ -126,7 +129,6 @@ body
     font-family: Georgia, "Times New Roman", Times, serif
     font-size: 11pt
     margin-right: 8px
-    flex: 1 1 auto
     text-align: center
 
   #skills-list .skill b
@@ -140,7 +142,7 @@ body
     width: 65% !important
     float: left !important
     clear: none !important
-
+    box-sizing: border-box !important
     border-right: 1px solid #ccc
     padding-right: 0.5rem
 
@@ -148,6 +150,7 @@ body
     width: 33% !important
     float: right !important
     clear: none !important
+    box-sizing: border-box !important
     padding-left: 0.5rem
 
   // Consistent section spacing
@@ -166,6 +169,3 @@ body
     font-size: 0.8em
     color: #999
 
-  @page
-    margin: 1cm
-    size: A4

--- a/src/styles/application.sass
+++ b/src/styles/application.sass
@@ -71,7 +71,6 @@ body
       color: #52A1CD
 
   #skills-list .skill
-    flex: 1 1 auto
     text-align: center
     padding: 2px 4px
 


### PR DESCRIPTION
## Summary
Adds complete print styling for the multi-profile CV, ensuring professional output when printing or exporting to PDF.

## Changes
- **print.css** — external stylesheet with base print resets and page break controls for `.experience` and `.project-description` entries
- **application.sass** — `@media print` blocks for:
  - Two-column layout (65%/33% split with float-based positioning)
  - Quasar component overrides (hide spinners, buttons, card borders)
  - Skills list print formatting (inline display, serif fonts)
  - Colour overrides for professional output
  - Section spacing and page break management
  - URL display after links for printed output
  - A4 page size with 1cm margins
- **index.html** — linked print.css stylesheet

## Testing
- `npm run build` passes
- Print preview shows clean two-column layout
- No orphaned entries across page breaks (page-break-inside: avoid on experience/project sections)
- Colours render correctly in print mode

## Notes
PR 4 of 5 (split from #3). Depends on #4 (multi-profile core).